### PR TITLE
Add Jest test setup for validateForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,19 @@ Una plataforma web donde el profesor:
 - ⏳ Generar contenido automático con IA  
 - ⏳ Personalizar logos y nombre de institución  
 - ⏳ Exportar planeación a PDF y Word *(próximamente)*  
-- ⏳ Panel de usuario con historial de planeaciones  
+- ⏳ Panel de usuario con historial de planeaciones
 - ⏳ Soporte multiformato (COBAC, SEP, UNAM, etc)
+
+---
+
+## 🧪 Pruebas
+
+Ejecuta las pruebas unitarias con **Jest** para validar la lógica del formulario.
+
+```bash
+npm install
+npm test
+```
 
 ---
 

--- a/js/planeacion.js
+++ b/js/planeacion.js
@@ -16,6 +16,10 @@ document.addEventListener('DOMContentLoaded', function () {
     loadComponent('navbar-placeholder', './components/navbar.html');
 });
 
+if (typeof module !== 'undefined') {
+    module.exports = { validateForm };
+}
+
 let currentTab = 0;
 const tabs = document.querySelectorAll('.tab');
 const steps = document.querySelectorAll('.step');
@@ -44,7 +48,7 @@ function validateForm(tabIndex) {
     // Validar inputs de texto, selects y textareas
     const inputs = tab.querySelectorAll('input[type=text], select, textarea');
     for (const input of inputs) {
-        if ((input.hasAttribute('required') || input.name) && input.value.trim() === '') {
+        if (input.hasAttribute('required') && input.value.trim() === '') {
             valid = false;
             alert('Por favor, completa todos los campos obligatorios.');
             break;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "planeacion-docente-ia",
+  "version": "1.0.0",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^21.1.0"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "testMatch": ["**/tests/**/*.test.js"]
+  }
+}

--- a/tests/planeacion.test.js
+++ b/tests/planeacion.test.js
@@ -1,0 +1,41 @@
+const { JSDOM } = require('jsdom');
+
+function loadModule(html) {
+  const dom = new JSDOM(html);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.alert = jest.fn();
+  jest.resetModules();
+  return require('../js/planeacion.js');
+}
+
+describe('validateForm', () => {
+  afterEach(() => {
+    delete global.window;
+    delete global.document;
+    delete global.alert;
+  });
+
+  test('ignores non-required fields', () => {
+    const { validateForm } = loadModule(`
+      <div class="tab">
+        <input type="text" name="opt">
+        <input type="text" name="req" required>
+      </div>
+    `);
+    const tab = document.querySelector('.tab');
+    const inputs = tab.querySelectorAll('input');
+    inputs[1].value = 'filled';
+    expect(validateForm(0)).toBe(true);
+  });
+
+  test('fails when required field empty', () => {
+    const { validateForm } = loadModule(`
+      <div class="tab">
+        <input type="text" name="opt">
+        <input type="text" name="req" required>
+      </div>
+    `);
+    expect(validateForm(0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest and jsdom
- export `validateForm` and ensure only required fields trigger errors
- add planeacion.test.js
- document test instructions in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68410b3baf548328bf077dabb19abfc9