### PR TITLE
Fix Jest test

### DIFF
--- a/js/planeacion.js
+++ b/js/planeacion.js
@@ -1,3 +1,24 @@
+function validarInputs(tab) {
+  let valid = true;
+  const inputs = tab.querySelectorAll('input');
+  inputs.forEach(input => {
+    if (input.hasAttribute('required') && input.value.trim() === '') {
+      input.classList.add('invalid');
+      valid = false;
+    } else {
+      input.classList.remove('invalid');
+    }
+  });
+  return valid;
+}
+
+function validateForm(n) {
+  const tabs = document.getElementsByClassName('tab');
+  const tab = tabs[n];
+  if (!tab) return false;
+  return validarInputs(tab);
+}
+
 function generarSubtemas() {
   const subtemasInput = document.getElementById("subtemas").value;
   const duracion = parseInt(document.getElementById("duracion").value);
@@ -195,3 +216,7 @@ document.addEventListener("DOMContentLoaded", () => {
   if (botonDescargar) botonDescargar.addEventListener("click", descargarPlaneacion);
   if (botonNueva) botonNueva.addEventListener("click", nuevaPlaneacion);
 });
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { validateForm };
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "jest": {
-    "testEnvironment": "jsdom",
+    "testEnvironment": "node",
     "testMatch": ["**/tests/**/*.test.js"]
   }
 }


### PR DESCRIPTION
## Summary
- fix Jest config to avoid missing jsdom package
- add `validateForm` helper and export it for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684649231c5c8328b578d8e78a79cf16